### PR TITLE
Adicionando parâmetro para limitar pesquisa em subdiretorios

### DIFF
--- a/restore_backup.sh
+++ b/restore_backup.sh
@@ -97,12 +97,12 @@ function get_file_path
 
     if [[ $APP ]]
     then
-        FILE_PATH_APP=$(find /home/cloud-db -type f -iname "$APP$LICENCA*.sql")
+        FILE_PATH_APP=$(find /home/cloud-db -maxdepth 1 -type f -iname "$APP$LICENCA*.sql")
     fi    
     
-    FILE_PATH_CLOUD=$(find /home/cloud-db -type f -iname "$LICENCA*.sql")
+    FILE_PATH_CLOUD=$(find /home/cloud-db -maxdepth 1 -type f -iname "$LICENCA*.sql")
 
-    FILE_PATH=$(find /home/cloud-db -type f -iname "$APP$LICENCA*.sql")
+    FILE_PATH=$(find /home/cloud-db -maxdepth 1 -type f -iname "$APP$LICENCA*.sql")
 }
 
 # $arg1 prefixo do nome da licença


### PR DESCRIPTION
### O que foi feito
Adicionando parâmetro -maxdepth 1 para limitar a busca do sql da licença no subsdiretório.

### Situação
Havia uma pasta de backup com os arquivos antigos dentro da cloud-db. Como a busca não era limitada por diretório, ele estava varrendo todos subdiretórios. Trazendo todas as ocorrências e tentando montar o path.

